### PR TITLE
support environments where docker is not located in /usr/bin

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -157,7 +157,7 @@ impl<'cfg> Docker<'cfg> {
     fn build<P: AsRef<Path>>(&self, path: P, pack_docker: &PackDocker) -> Result<()> {
         let image_tag = pack_docker.tag(self)?;
         // FIXME: take from user
-        let dockerbin = ::which::which("/usr/bin/docker")?;
+        let dockerbin = ::which::which("docker")?;
         let status = Command::new(dockerbin)
             .current_dir(&path)
             .arg("build")


### PR DESCRIPTION
Since NixOS doesn't locates each executable in `/usr/bin` but their own directories like `/nix/store/azj3bxm5c3gsk29ykvqawp5lg3fkrx4n-docker-18.09.0/bin/docker`, `cargo-pack-docker` fails to search  for Docker in such environments. 
This patch looks for `docker`, assuming `docker` is in users' `PATH`.
I think this method is configurable enough because users can set their `PATH` right before executing `cargo-pack-docker` if they want to override the default `docker`.